### PR TITLE
fix: prefix process access in browser with globalThis

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -209,8 +209,8 @@ function load (): string | null | undefined {
   }
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
-  if (!r && typeof process !== 'undefined' && 'env' in process) {
-    r = process.env.DEBUG
+  if (!r && typeof globalThis.process !== 'undefined' && 'env' in globalThis.process) {
+    r = globalThis.process.env.DEBUG
   }
 
   return r


### PR DESCRIPTION
Detect process in globalThis instead of global otherwise webpack users have to install extra polyfills.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
