### PR TITLE
fix: Change import of 'ms' to namespace import

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,7 +6,7 @@
 /**
  * This is the web browser implementation of `debug()`.
  */
-import humanize from 'ms'
+import * as humanize from 'ms'
 import setup from './common.js'
 
 const storage = localstorage()

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,7 +5,7 @@
  * This is the common logic for both the Node.js and web browser
  * implementations of `debug()`.
  */
-import humanize from 'ms'
+import * as humanize from 'ms'
 import type { Debug, Debugger } from './index.js'
 
 export default function setup (env: any): Debug {

--- a/src/node.ts
+++ b/src/node.ts
@@ -16,7 +16,7 @@
 
 import tty from 'node:tty'
 import util from 'node:util'
-import humanize from 'ms'
+import * as humanize from 'ms'
 import supportsColor from 'supports-color'
 import setup from './common.js'
 


### PR DESCRIPTION
## Title

Libp2p is breaking in the browser

## Description

fixes https://github.com/libp2p/js-libp2p/issues/3256


## Notes & open questions

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
