### PR TITLE
fix: fall through to logging

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -118,11 +118,11 @@ export default function setup (env: any): Debug {
 
       if (options?.onLog != null) {
         options.onLog(...args)
-      } else {
-        // @ts-expect-error log is not in the types
-        const logFn = self.log || createDebug.log
-        logFn.apply(self, args)
       }
+
+      // @ts-expect-error log is not in the types
+      const logFn = self.log || createDebug.log
+      logFn.apply(self, args)
     }
 
     debug.namespace = namespace

--- a/src/format.ts
+++ b/src/format.ts
@@ -15,11 +15,12 @@ export function format (...params: any[]): string {
 
       switch (flag) {
         case 'o':
-          if (Array.isArray(arg)) {
-            arg = JSON.stringify(arg)
+          if (arg instanceof Error) {
+            arg = arg.toString()
           } else {
-            arg = `${arg}`
+            arg = JSON.stringify(arg)
           }
+
           break
         case 's':
           arg = `${arg}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export interface Debug {
   enable(namespaces: string | boolean): void
   enabled(namespaces: string): boolean
   formatArgs(this: Debugger, args: any[]): void
-  log(...args: any[]): any
+  log(fmt: string, ...args: any[]): unknown
   selectColor(namespace: string): string | number
   humanize: typeof ms
   useColors(): boolean
@@ -75,7 +75,7 @@ export interface Debugger {
   color: string
   diff: number
   enabled: boolean
-  log(...args: any[]): any
+  log(fmt: string, ...args: any[]): unknown
   namespace: string
   destroy(): boolean
   extend(namespace: string, delimiter?: string): Debugger

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -39,7 +39,7 @@ describe('format', function () {
 
   it('should format object string (%o)', () => {
     const res = format('%o', 'foo')
-    expect(res).to.equal('foo')
+    expect(res).to.equal('"foo"')
   })
 
   it('should format error (%o)', () => {


### PR DESCRIPTION
Log the message after the onLog callback is invoked

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
